### PR TITLE
PIP-1310: Fix imports and setup go mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+.vscode/
+__pycache__
+*.pyc
+gubernator.egg-info/
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "mustache"]
-	path = mustache
-	url = git://github.com/mustache/spec.git

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ package main
 import (
     "fmt"
 
-    "github.com/aymerick/raymond"
+    "github.com/mailgun/raymond"
 )
 
 func main() {
@@ -116,7 +116,7 @@ package main
 import (
     "fmt"
 
-    "github.com/aymerick/raymond"
+    "github.com/mailgun/raymond"
 )
 
 func main() {
@@ -200,7 +200,7 @@ package main
 import (
   "fmt"
 
-  "github.com/aymerick/raymond"
+  "github.com/mailgun/raymond"
 )
 
 func main() {
@@ -1315,7 +1315,7 @@ package main
 import (
     "fmt"
 
-    "github.com/aymerick/raymond/lexer"
+    "github.com/mailgun/raymond/lexer"
 )
 
 func main() {
@@ -1357,8 +1357,8 @@ package main
 import (
     "fmt"
 
-    "github.com/aymerick/raymond/ast"
-    "github.com/aymerick/raymond/parser"
+    "github.com/mailgun/raymond/ast"
+    "github.com/mailgun/raymond/parser"
 )
 
 fu  nc main() {

--- a/eval.go
+++ b/eval.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aymerick/raymond/ast"
+	"github.com/mailgun/raymond/ast"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mailgun/raymond
+
+go 1.16
+
+require gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/handlebars/base_test.go
+++ b/handlebars/base_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mailgun/raymond"
 )
 
 // cf. https://github.com/aymerick/go-fuzz-tests/raymond

--- a/handlebars/basic_test.go
+++ b/handlebars/basic_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mailgun/raymond"
 )
 
 //

--- a/handlebars/data_test.go
+++ b/handlebars/data_test.go
@@ -3,7 +3,7 @@ package handlebars
 import (
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mailgun/raymond"
 )
 
 //

--- a/handlebars/helpers_test.go
+++ b/handlebars/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mailgun/raymond"
 )
 
 //

--- a/handlebars/subexpressions_test.go
+++ b/handlebars/subexpressions_test.go
@@ -3,7 +3,7 @@ package handlebars
 import (
 	"testing"
 
-	"github.com/aymerick/raymond"
+	"github.com/mailgun/raymond"
 )
 
 //

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/aymerick/raymond/ast"
-	"github.com/aymerick/raymond/lexer"
+	"github.com/mailgun/raymond/ast"
+	"github.com/mailgun/raymond/lexer"
 )
 
 // References:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aymerick/raymond/ast"
-	"github.com/aymerick/raymond/lexer"
+	"github.com/mailgun/raymond/ast"
+	"github.com/mailgun/raymond/lexer"
 )
 
 type parserTest struct {

--- a/parser/whitespace.go
+++ b/parser/whitespace.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"regexp"
 
-	"github.com/aymerick/raymond/ast"
+	"github.com/mailgun/raymond/ast"
 )
 
 // whitespaceVisitor walks through the AST to perform whitespace control

--- a/template.go
+++ b/template.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/aymerick/raymond/ast"
-	"github.com/aymerick/raymond/parser"
+	"github.com/mailgun/raymond/ast"
+	"github.com/mailgun/raymond/parser"
 )
 
 // Template represents a handlebars template.


### PR DESCRIPTION
Purpose

Fixing imports to point to the forked repo and configure go mod. This forked library is needed to add additional handlebar features for mailgun/temple as the original repo is no longer being maintained.

https://mailgun.atlassian.net/browse/PIP-1310

Reference: https://github.com/aymerick/raymond/issues/40