### PR TITLE
PIP-1372: Fix go mod release to match v2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ package main
 import (
     "fmt"
 
-    "github.com/mailgun/raymond"
+    "github.com/mailgun/raymond/v2"
 )
 
 func main() {
@@ -116,7 +116,7 @@ package main
 import (
     "fmt"
 
-    "github.com/mailgun/raymond"
+    "github.com/mailgun/raymond/v2"
 )
 
 func main() {
@@ -200,7 +200,7 @@ package main
 import (
   "fmt"
 
-  "github.com/mailgun/raymond"
+  "github.com/mailgun/raymond/v2"
 )
 
 func main() {
@@ -1315,7 +1315,7 @@ package main
 import (
     "fmt"
 
-    "github.com/mailgun/raymond/lexer"
+    "github.com/mailgun/raymond/v2/lexer"
 )
 
 func main() {
@@ -1357,8 +1357,8 @@ package main
 import (
     "fmt"
 
-    "github.com/mailgun/raymond/ast"
-    "github.com/mailgun/raymond/parser"
+    "github.com/mailgun/raymond/v2/ast"
+    "github.com/mailgun/raymond/v2/parser"
 )
 
 fu  nc main() {

--- a/eval.go
+++ b/eval.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mailgun/raymond/ast"
+	"github.com/mailgun/raymond/v2/ast"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mailgun/raymond
+module github.com/mailgun/raymond/v2
 
 go 1.16
 

--- a/handlebars/base_test.go
+++ b/handlebars/base_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/mailgun/raymond"
+	"github.com/mailgun/raymond/v2"
 )
 
 // cf. https://github.com/aymerick/go-fuzz-tests/raymond

--- a/handlebars/basic_test.go
+++ b/handlebars/basic_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/mailgun/raymond"
+	"github.com/mailgun/raymond/v2"
 )
 
 //

--- a/handlebars/data_test.go
+++ b/handlebars/data_test.go
@@ -3,7 +3,7 @@ package handlebars
 import (
 	"testing"
 
-	"github.com/mailgun/raymond"
+	"github.com/mailgun/raymond/v2"
 )
 
 //

--- a/handlebars/helpers_test.go
+++ b/handlebars/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mailgun/raymond"
+	"github.com/mailgun/raymond/v2"
 )
 
 //

--- a/handlebars/subexpressions_test.go
+++ b/handlebars/subexpressions_test.go
@@ -3,7 +3,7 @@ package handlebars
 import (
 	"testing"
 
-	"github.com/mailgun/raymond"
+	"github.com/mailgun/raymond/v2"
 )
 
 //

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/mailgun/raymond/ast"
-	"github.com/mailgun/raymond/lexer"
+	"github.com/mailgun/raymond/v2/ast"
+	"github.com/mailgun/raymond/v2/lexer"
 )
 
 // References:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/mailgun/raymond/ast"
-	"github.com/mailgun/raymond/lexer"
+	"github.com/mailgun/raymond/v2/ast"
+	"github.com/mailgun/raymond/v2/lexer"
 )
 
 type parserTest struct {

--- a/parser/whitespace.go
+++ b/parser/whitespace.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"regexp"
 
-	"github.com/mailgun/raymond/ast"
+	"github.com/mailgun/raymond/v2/ast"
 )
 
 // whitespaceVisitor walks through the AST to perform whitespace control

--- a/template.go
+++ b/template.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/mailgun/raymond/ast"
-	"github.com/mailgun/raymond/parser"
+	"github.com/mailgun/raymond/v2/ast"
+	"github.com/mailgun/raymond/v2/parser"
 )
 
 // Template represents a handlebars template.


### PR DESCRIPTION
### Purpose
Fixes the go mod version to match version 2 release. 

https://mailgun.atlassian.net/browse/PIP-1372