### PR TITLE
PIP-1372: fix ifGt helper func

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -210,17 +210,17 @@ var helperTests = []Test{
 	},
 	{
 		"#ifGt helper with true literal from params",
-		`{{#ifGt foo bar}}foo is greater than 10{{/ifGt}}`,
+		`{{#ifGt foo bar}}foo is greater than bar{{/ifGt}}`,
 		map[string]interface{}{"foo": 5, "bar": 0},
 		nil, nil, nil,
-		`foo is greater than 10`,
+		`foo is greater than bar`,
 	},
 	{
-		"#ifGt helper with string comparison, is improper imput should return empty string",
-		`{{#ifGt foo bar}}foo is greater than 10{{/ifGt}}`,
+		"#ifGt helper with string comparison",
+		`{{#ifGt foo bar}}foo is greater than bar{{/ifGt}}`,
 		map[string]interface{}{"foo": "5", "bar": "0"},
 		nil, nil, nil,
-		``,
+		`foo is greater than bar`,
 	},
 	{
 		"#ifGt helper with false literal from params",


### PR DESCRIPTION
### Purpose
When `ifGtHelper` func is called, the a and b params are being passed as `float64` variables.  Instead of being strict on the type it receives it should attempt to convert the types to float64. e.g. convert string -> float64, int -> float64 Then do the comparison.  This is needed because the values passed to the template are not known until runtime. 

https://mailgun.atlassian.net/browse/PIP-1372