### PR TITLE
Add support for variadic helper arguments

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -1,6 +1,8 @@
 package raymond
 
-import "testing"
+import (
+	"testing"
+)
 
 var evalTests = []Test{
 	{

--- a/helper_test.go
+++ b/helper_test.go
@@ -2,6 +2,7 @@ package raymond
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,10 @@ func gnakHelper(nb int) string {
 	}
 
 	return result
+}
+
+func variadicHelper(values ...string) string {
+	return strings.Join(values, ",")
 }
 
 //
@@ -105,6 +110,14 @@ var helperTests = []Test{
 		map[string]interface{}{"echo": echoHelper},
 		nil,
 		`GnAK!GnAK!GnAK!`,
+	},
+	{
+		"helper with variadic parameters",
+		`{{join "foo" "bar" "baz"}}`,
+		nil, nil,
+		map[string]interface{}{"join": variadicHelper},
+		nil,
+		`foo,bar,baz`,
 	},
 	{
 		"#if helper with true literal",


### PR DESCRIPTION
### Purpose
This adds support for variadic arguments to helpers.

###  Example

#### Template
```hbs
{{join "foo" "bar" "baz"}}
```

#### Example
```go
package main

import (
	"fmt"
	"strings"

	"github.com/mailgun/raymond/v2"
)

func main() {
	source := `{{join "foo" "bar" "baz"}}`

	raymond.RegisterHelper("join", func(values ...string) string {
		return strings.Join(values, ",")
	})
	output := raymond.MustRender(source, nil)

	fmt.Print(output)
	// Prints: foo,bar,baz
}

```