### PR TITLE
fix(eval): fixes variadic helper calls

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -617,7 +617,7 @@ func (v *evalVisitor) callFunc(name string, funcVal reflect.Value, options *Opti
 	}
 
 	// check and collect arguments
-	args := make([]reflect.Value, numIn+vaCount)
+	args := make([]reflect.Value, 0, numIn+vaCount)
 	for i, param := range params {
 		arg := reflect.ValueOf(param)
 		var argType reflect.Type
@@ -652,11 +652,11 @@ func (v *evalVisitor) callFunc(name string, funcVal reflect.Value, options *Opti
 			}
 		}
 
-		args[i] = arg
+		args = append(args, arg)
 	}
 
 	if addOptions {
-		args[numIn+vaCount-1] = reflect.ValueOf(options)
+		args = append(args, reflect.ValueOf(options))
 	}
 
 	result := funcVal.Call(args)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mailgun/raymond/v2
+module github.com/pbedat/raymond
 
 go 1.16
 

--- a/handlebars/helpers_test.go
+++ b/handlebars/helpers_test.go
@@ -94,10 +94,16 @@ func detectDataHelper(options *raymond.Options) string {
 	return ""
 }
 
-//
+func variadicHelper(a string, b ...bool) string {
+	if len(b) > 0 && b[0] {
+		return "TRUE " + a
+	}
+	return "FALSE " + a
+}
+
 // Those tests come from:
-//   https://github.com/wycats/handlebars.js/blob/master/spec/helper.js
 //
+//	https://github.com/wycats/handlebars.js/blob/master/spec/helper.js
 var helpersTests = []Test{
 	{
 		"helper with complex lookup",
@@ -656,7 +662,26 @@ var helpersTests = []Test{
 		nil,
 		"GOODBYE cruel WORLD goodbye",
 	},
-
+	{"variadic helper",
+		`{{ variadicHelper "foo" true}}`,
+		map[string]string{},
+		nil,
+		map[string]interface{}{
+			"variadicHelper": variadicHelper,
+		},
+		nil,
+		"TRUE foo",
+	},
+	{"variadic helper without args",
+		`{{ variadicHelper "foo"}}`,
+		map[string]string{},
+		nil,
+		map[string]interface{}{
+			"variadicHelper": variadicHelper,
+		},
+		nil,
+		"FALSE foo",
+	},
 	// @todo "block params" tests
 }
 


### PR DESCRIPTION
see https://github.com/aymerick/raymond/issues/14

args was fixed to the number of arguments of the function, but only iterated over the provided parameters

the last arg remained an invalid value that led to a panic

the args are now appended on demand to correctly match the variadic signature