### PR TITLE
Add 'else' support for equal helper

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -495,7 +495,8 @@ func equalHelper(a interface{}, b interface{}, options *Options) interface{} {
 		return options.Fn()
 	}
 
-	return ""
+	// Evaluate possible else condition.
+	return options.Inverse()
 }
 
 // floatValue attempts to convert value into a float64 and returns an error if it fails.


### PR DESCRIPTION
This PR aims to enable support for an `else` block when using the `equal` helper. Currently I'm using Mailgun's template feature but there are HTML blocks that I want to render _only_ if two strings are not equal. Currently, `equal` has no support for the `else` block, unlike `if`, `unless`, etc. 